### PR TITLE
ai - do not require quotes

### DIFF
--- a/__tests__/Invoke-OAIChat.tests.ps1
+++ b/__tests__/Invoke-OAIChat.tests.ps1
@@ -22,13 +22,13 @@ Describe "Invoke-OAIChat" -Tag Invoke-OAIChat {
      
         $actual.Parameters.Instructions.Aliases.Count | Should -Be 0
      
-        $actual.Parameters.Keys.Contains('model') | Should -Be $true
+        $actual.Parameters.Keys.Contains('Model') | Should -Be $true
 
-        $ValidateSet = $actual.Parameters.model.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
-        $ValidateSet | Should -Not -BeNullOrEmpty     
+        # $ValidateSet = $actual.Parameters.model.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+        # $ValidateSet | Should -Not -BeNullOrEmpty     
 
-        $validValues = $actual.Parameters['model'].Attributes.ValidValues
-        $validValues | Should -Be @('gpt-4', 'gpt-3.5-turbo', 'gpt-3.5-turbo-16k', 'gpt-4-1106-preview', 'gpt-4-turbo-preview', 'gpt-3.5-turbo-1106')
+        # $validValues = $actual.Parameters['model'].Attributes.ValidValues
+        # $validValues | Should -Be @('gpt-4', 'gpt-3.5-turbo', 'gpt-3.5-turbo-16k', 'gpt-4-1106-preview', 'gpt-4-turbo-preview', 'gpt-3.5-turbo-1106')
 
         # $validateScript = $actual.Parameters.model.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateScriptAttribute] }
         # $validateScript | Should -Not -BeNullOrEmpty


### PR DESCRIPTION
Now you can just do:

`ai when was justin bieber born?`

Also makes datatypes more strict, which I imagine helps with the ValueFromRemainingArguments

The issue you may remember @dfinke is that you can no longer do the following without a qualifying parameter:

`git status | ai 'write a detailed commit message'`

You have to specify `Instructions`

`git status | ai -Instructions 'write a detailed commit message'`

I think the tradeoff is worth it, but I also understanding loving a demo, I can't let go. So either, way. 